### PR TITLE
Improve login retry logic

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,14 +7,24 @@ import 'package:flutter/material.dart';
 import 'app.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'firebase_options.dart';
 import 'core/routes/app_routes.dart';
 import 'shared/services/facade_service.dart';
 
+/// Entry point of the mobile app.
+///
+/// Initializes Firebase with offline persistence, loads the saved facade and
+/// launches the application with the appropriate initial route depending on the
+/// current authentication state.
 Future<void> main() async {
   // Required to use platform channels before `runApp`.
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(options: DefaultFirebaseOptions.currentPlatform);
+  FirebaseFirestore.instance.settings = const Settings(
+    persistenceEnabled: true,
+    cacheSizeBytes: Settings.CACHE_SIZE_UNLIMITED,
+  );
   await FacadeService().loadSavedFacade();
   final initialRoute = FirebaseAuth.instance.currentUser == null
       ? AppRoutes.login


### PR DESCRIPTION
## Summary
- enable Firestore offline persistence in `main`
- load login document with exponential retries and cache fallback
- show an error when both network and cached data are unavailable

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684fd423f8888328a40d775f6689233e